### PR TITLE
fix: 🐛 <html> の lang の属性値を en から ja に修正した

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
   <head>
     <meta charset="utf-8" />
     <title>幻水総選挙2021</title>


### PR DESCRIPTION
close #55